### PR TITLE
Fix event delivery: no ack-after-nack, skip unregistered event types

### DIFF
--- a/es/client.go
+++ b/es/client.go
@@ -2,6 +2,7 @@ package es
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 )
@@ -83,6 +84,13 @@ func NewClient(ctx context.Context, pcfg *ProviderConfig, reg Registry) (cli Cli
 		handler := MessageHandler(func(ctx context.Context, payload []byte) error {
 			evt, err := reg.ParseEvent(ctx, payload)
 			if err != nil {
+				// The shared topic carries every service's published events;
+				// ones this service has no registration for can never be
+				// handled, so skip them instead of nacking into a redelivery
+				// loop that jams the subscription.
+				if errors.Is(err, ErrNotFound) {
+					return nil
+				}
 				return err
 			}
 

--- a/es/providers/stream/gpub/streamer.go
+++ b/es/providers/stream/gpub/streamer.go
@@ -67,7 +67,10 @@ func (s *streamer) loop(sub *pubsub.Subscription, handler es.MessageHandler) {
 
 		if err := handler(s.cctx, raw); err != nil {
 			s.errCh <- fmt.Errorf("could not handle message: %w", err)
+			// Nack only: falling through to Ack here would confirm the
+			// message and the failed event would never be redelivered.
 			msg.Nack()
+			return
 		}
 		msg.Ack()
 	}


### PR DESCRIPTION
Two subscriber-side delivery fixes found while building the async mass payout import:

1. **gpub acked messages after nacking them.** The subscriber callback nacked on handler error but fell through to an unconditional Ack, confirming the delivery anyway — any handler failure silently dropped the event with no redelivery (mpub already returns after nack).

2. **Unknown event types poison the subscription once nacks work.** The shared topic carries every service's published events; ParseEvent fails with ErrNotFound for types a consumer never registered. Those can never succeed, so the client now ack-skips them instead of redelivering forever (which blocks ordered delivery behind the poison message).

Both were reproduced and verified against the Pub/Sub emulator with cross-service consumers (payouts ↔ profile).

⚠️ inflow-tech/api's masspayout-async-import branch depends on these fixes being tagged and picked up before it ships — its external-group subscribers are the first cross-service consumers outside fraud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)