### PR TITLE
gpub: push-mode streamer for Pub/Sub push subscriptions

### DIFF
--- a/es/client.go
+++ b/es/client.go
@@ -3,6 +3,7 @@ package es
 import (
 	"context"
 	"errors"
+	"net/http"
 
 	"github.com/google/uuid"
 )
@@ -48,6 +49,15 @@ func (c *client) Unit(ctx context.Context) (Unit, error) {
 
 func (c *client) MigrateDb(ctx context.Context) error {
 	return c.conn.MigrateDb(ctx)
+}
+
+// PushHandler returns the streamer's HTTP delivery handler when the
+// configured streamer consumes via push (see PushReceiver).
+func (c *client) PushHandler() (http.Handler, bool) {
+	if pr, ok := c.publisher.(PushReceiver); ok {
+		return pr.PushHandler(), true
+	}
+	return nil, false
 }
 
 func NewClient(ctx context.Context, pcfg *ProviderConfig, reg Registry) (cli Client, err error) {

--- a/es/config.go
+++ b/es/config.go
@@ -24,6 +24,11 @@ type StreamConfig struct {
 type GcpPubSubConfig struct {
 	ProjectId string
 	TopicId   string
+	// Mode selects how subscriptions are consumed: "pull" (default) runs
+	// in-process receive loops and self-provisions subscriptions; "push"
+	// serves deliveries over HTTP (see PushReceiver) and expects
+	// subscriptions to be provisioned externally.
+	Mode string
 }
 
 type NatsConfig struct {

--- a/es/providers/stream/gpub/provider.go
+++ b/es/providers/stream/gpub/provider.go
@@ -15,7 +15,14 @@ func New(ctx context.Context, cfg *es.ProviderConfig) (es.Streamer, error) {
 		return nil, fmt.Errorf("invalid pubsub config")
 	}
 
-	return NewStreamer(ctx, cfg.Service, cfg.Stream.PubSub)
+	switch cfg.Stream.PubSub.Mode {
+	case "", "pull":
+		return NewStreamer(ctx, cfg.Service, cfg.Stream.PubSub)
+	case "push":
+		return NewPushStreamer(ctx, cfg.Service, cfg.Stream.PubSub)
+	default:
+		return nil, fmt.Errorf("invalid pubsub mode: %s", cfg.Stream.PubSub.Mode)
+	}
 }
 
 func init() {

--- a/es/providers/stream/gpub/push.go
+++ b/es/providers/stream/gpub/push.go
@@ -1,0 +1,127 @@
+package gpub
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path"
+	"sync"
+
+	"cloud.google.com/go/pubsub"
+	"github.com/go-apis/eventsourcing/es"
+)
+
+// pushEnvelope is the JSON body Pub/Sub sends to push endpoints.
+// Message.Data is base64 in the wire format; encoding/json decodes it
+// into []byte directly.
+type pushEnvelope struct {
+	Message struct {
+		Data      []byte `json:"data"`
+		MessageId string `json:"messageId"`
+	} `json:"message"`
+	Subscription string `json:"subscription"`
+}
+
+// pushStreamer serves Pub/Sub push deliveries over HTTP instead of running
+// pull loops. Subscriptions are provisioned externally (Terraform); handlers
+// registered via AddHandler are routed by subscription id.
+type pushStreamer struct {
+	service string
+	topicId string
+	client  *pubsub.Client
+	topic   *pubsub.Topic
+
+	errCh chan error
+
+	mu       sync.RWMutex
+	handlers map[string]es.MessageHandler
+}
+
+func (s *pushStreamer) subscriptionId(name string) string {
+	id := s.topicId + "__" + s.service
+	if name != "" {
+		id += "-" + name
+	}
+	return id
+}
+
+func (s *pushStreamer) AddHandler(ctx context.Context, name string, handler es.MessageHandler) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	id := s.subscriptionId(name)
+	if _, exists := s.handlers[id]; exists {
+		return fmt.Errorf("handler already registered for subscription %q", id)
+	}
+	s.handlers[id] = handler
+	return nil
+}
+
+func (s *pushStreamer) PushHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+
+		var env pushEnvelope
+		if err := json.NewDecoder(r.Body).Decode(&env); err != nil {
+			// Malformed body will never parse on redelivery either.
+			http.Error(w, "bad envelope", http.StatusBadRequest)
+			return
+		}
+
+		s.mu.RLock()
+		handler, ok := s.handlers[path.Base(env.Subscription)]
+		s.mu.RUnlock()
+		if !ok {
+			// A subscription pointed at this endpoint that we have no
+			// handler for is a provisioning error; 404 keeps it visible in
+			// push metrics rather than silently acking.
+			http.Error(w, "unknown subscription", http.StatusNotFound)
+			return
+		}
+
+		if err := handler(r.Context(), env.Message.Data); err != nil {
+			select {
+			case s.errCh <- fmt.Errorf("could not handle message %s: %w", env.Message.MessageId, err):
+			default:
+			}
+			// Non-2xx nacks the delivery so Pub/Sub redelivers with backoff.
+			http.Error(w, "handler error", http.StatusInternalServerError)
+			return
+		}
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func (s *pushStreamer) Publish(ctx context.Context, evt *es.Event) error {
+	return publishEvent(ctx, s.topic, evt)
+}
+
+func (s *pushStreamer) Errors() <-chan error {
+	return s.errCh
+}
+
+func (s *pushStreamer) Close(ctx context.Context) error {
+	s.topic.Stop()
+	return s.client.Close()
+}
+
+func NewPushStreamer(ctx context.Context, service string, config *es.GcpPubSubConfig) (es.Streamer, error) {
+	client, err := pubsub.NewClient(ctx, config.ProjectId)
+	if err != nil {
+		return nil, err
+	}
+
+	return &pushStreamer{
+		service:  service,
+		topicId:  config.TopicId,
+		client:   client,
+		topic:    newTopic(client, config.TopicId),
+		errCh:    make(chan error, 100),
+		handlers: map[string]es.MessageHandler{},
+	}, nil
+}

--- a/es/providers/stream/gpub/push_test.go
+++ b/es/providers/stream/gpub/push_test.go
@@ -1,0 +1,127 @@
+package gpub
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/go-apis/eventsourcing/es"
+)
+
+func newTestPushStreamer() *pushStreamer {
+	return &pushStreamer{
+		service:  "fraud",
+		errCh:    make(chan error, 10),
+		handlers: map[string]es.MessageHandler{},
+	}
+}
+
+func envelope(subscription, data string) string {
+	return fmt.Sprintf(`{
+		"message": {"data": %q, "messageId": "m1"},
+		"subscription": %q
+	}`, base64.StdEncoding.EncodeToString([]byte(data)), subscription)
+}
+
+func post(h http.Handler, body string) *httptest.ResponseRecorder {
+	req := httptest.NewRequest(http.MethodPost, "/pubsub/push", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	h.ServeHTTP(w, req)
+	return w
+}
+
+func TestPushHandlerAcks(t *testing.T) {
+	s := newTestPushStreamer()
+
+	var got []byte
+	s.handlers["inflow__fraud"] = func(ctx context.Context, payload []byte) error {
+		got = payload
+		return nil
+	}
+
+	w := post(s.PushHandler(), envelope("projects/p/subscriptions/inflow__fraud", "hello"))
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+	if string(got) != "hello" {
+		t.Fatalf("expected decoded payload %q, got %q", "hello", got)
+	}
+}
+
+func TestPushHandlerNacksOnHandlerError(t *testing.T) {
+	s := newTestPushStreamer()
+	s.handlers["inflow__fraud"] = func(ctx context.Context, payload []byte) error {
+		return errors.New("boom")
+	}
+
+	w := post(s.PushHandler(), envelope("projects/p/subscriptions/inflow__fraud", "x"))
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 (nack), got %d", w.Code)
+	}
+
+	select {
+	case err := <-s.Errors():
+		if !strings.Contains(err.Error(), "boom") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	default:
+		t.Fatal("expected handler error on error channel")
+	}
+}
+
+func TestPushHandlerUnknownSubscription(t *testing.T) {
+	s := newTestPushStreamer()
+
+	w := post(s.PushHandler(), envelope("projects/p/subscriptions/inflow__other", "x"))
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestPushHandlerBadEnvelope(t *testing.T) {
+	s := newTestPushStreamer()
+
+	w := post(s.PushHandler(), "{not json")
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestPushHandlerRejectsGet(t *testing.T) {
+	s := newTestPushStreamer()
+
+	req := httptest.NewRequest(http.MethodGet, "/pubsub/push", nil)
+	w := httptest.NewRecorder()
+	s.PushHandler().ServeHTTP(w, req)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestAddHandlerNaming(t *testing.T) {
+	s := newTestPushStreamer()
+	s.topicId = "inflow"
+
+	if err := s.AddHandler(context.Background(), "", func(ctx context.Context, payload []byte) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.handlers["inflow__fraud"]; !ok {
+		t.Fatal("expected base subscription registration")
+	}
+
+	if err := s.AddHandler(context.Background(), "sub2", func(ctx context.Context, payload []byte) error { return nil }); err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := s.handlers["inflow__fraud-sub2"]; !ok {
+		t.Fatal("expected suffixed subscription registration")
+	}
+
+	if err := s.AddHandler(context.Background(), "", func(ctx context.Context, payload []byte) error { return nil }); err == nil {
+		t.Fatal("expected duplicate registration to error")
+	}
+}

--- a/es/providers/stream/gpub/streamer.go
+++ b/es/providers/stream/gpub/streamer.go
@@ -112,6 +112,10 @@ func (s *streamer) AddHandler(ctx context.Context, name string, handler es.Messa
 }
 
 func (s *streamer) Publish(ctx context.Context, evt *es.Event) error {
+	return publishEvent(ctx, s.topic, evt)
+}
+
+func publishEvent(ctx context.Context, topic *pubsub.Topic, evt *es.Event) error {
 	orderingKey := fmt.Sprintf("%s:%s:%s:%d", evt.Namespace, evt.AggregateId.String(), evt.AggregateType, evt.Version)
 	data, err := es.MarshalEvent(ctx, evt)
 	if err != nil {
@@ -123,11 +127,20 @@ func (s *streamer) Publish(ctx context.Context, evt *es.Event) error {
 		OrderingKey: orderingKey,
 	}
 
-	rsp := s.topic.Publish(ctx, msg)
+	rsp := topic.Publish(ctx, msg)
 	if _, err := rsp.Get(ctx); err != nil {
 		return err
 	}
 	return nil
+}
+
+func newTopic(client *pubsub.Client, topicId string) *pubsub.Topic {
+	topic := client.Topic(topicId)
+	topic.EnableMessageOrdering = true
+	topic.PublishSettings.ByteThreshold = 5000
+	topic.PublishSettings.CountThreshold = 10
+	topic.PublishSettings.DelayThreshold = 100 * time.Millisecond
+	return topic
 }
 
 func (s *streamer) Errors() <-chan error {
@@ -156,11 +169,7 @@ func NewStreamer(ctx context.Context, service string, config *es.GcpPubSubConfig
 		return nil, err
 	}
 
-	topic := client.Topic(config.TopicId)
-	topic.EnableMessageOrdering = true
-	topic.PublishSettings.ByteThreshold = 5000
-	topic.PublishSettings.CountThreshold = 10
-	topic.PublishSettings.DelayThreshold = 100 * time.Millisecond
+	topic := newTopic(client, config.TopicId)
 
 	cctx, cancel := context.WithCancel(ctx)
 	s := &streamer{

--- a/es/streamer.go
+++ b/es/streamer.go
@@ -2,9 +2,24 @@ package es
 
 import (
 	"context"
+	"net/http"
 )
 
 type StreamerFactory func(ctx context.Context, cfg *ProviderConfig) (Streamer, error)
+
+// PushReceiver is implemented by streamers that consume deliveries over
+// HTTP (e.g. Pub/Sub push subscriptions) instead of in-process pull loops.
+// The returned handler acknowledges a delivery with 2xx and rejects it for
+// redelivery with 5xx.
+type PushReceiver interface {
+	PushHandler() http.Handler
+}
+
+// PushHandlerProvider is implemented by Client when the configured streamer
+// consumes over HTTP; mount the returned handler on the service's router.
+type PushHandlerProvider interface {
+	PushHandler() (http.Handler, bool)
+}
 
 type EventPublisher interface {
 	Publish(ctx context.Context, evt *Event) error


### PR DESCRIPTION
Adds `STREAM_PUBSUB_MODE=push` to the gpub provider. In push mode the streamer serves Pub/Sub push deliveries over HTTP instead of running in-process pull loops:

- `AddHandler` registers handlers keyed by subscription id (`<topic>__<service>[-<name>]`) — subscriptions are provisioned externally (Terraform), not self-created.
- `PushHandler()` decodes the push envelope, routes by subscription basename, calls the registered `es.MessageHandler` with the request context, returns 204 to ack / 500 to nack (Pub/Sub redelivers with backoff), 404 for unknown subscriptions, 400 for malformed envelopes.
- `es.Client` now satisfies `es.PushHandlerProvider` (`PushHandler() (http.Handler, bool)`) so services can mount the route without any breaking interface change; pull mode returns false.
- Publish path shared between modes (`publishEvent`/`newTopic`).

Motivation: lets the inflow api consumers run CPU-throttled and scale to zero on Cloud Run (removes the always-allocated-CPU requirement of pull loops), with platform-level OIDC auth on the push endpoint.

Note: `TestEventRegistry` (es) and `TestIt` (apub, needs an AWS profile) fail on main already; untouched here. New push tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)