### PR TITLE
gpub: fix SA1019 lint on push streamer import

### DIFF
--- a/es/providers/stream/gpub/push.go
+++ b/es/providers/stream/gpub/push.go
@@ -8,6 +8,7 @@ import (
 	"path"
 	"sync"
 
+	//nolint:staticcheck // v1 client kept for parity with the pull streamer; v2 migration is a separate change.
 	"cloud.google.com/go/pubsub"
 	"github.com/go-apis/eventsourcing/es"
 )


### PR DESCRIPTION
Follow-up to #64: scoped nolint on the v1 pubsub import in push.go, matching the pull streamer's existing (grandfathered) usage. pubsub/v2 migration should be its own change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)