### PR TITLE
gpub: log push delivery failures

### DIFF
--- a/es/providers/stream/gpub/push.go
+++ b/es/providers/stream/gpub/push.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"path"
 	"sync"
@@ -85,6 +86,11 @@ func (s *pushStreamer) PushHandler() http.Handler {
 		}
 
 		if err := handler(r.Context(), env.Message.Data); err != nil {
+			slog.ErrorContext(r.Context(), "pubsub push delivery failed",
+				"subscription", env.Subscription,
+				"messageId", env.Message.MessageId,
+				"error", err,
+			)
 			select {
 			case s.errCh <- fmt.Errorf("could not handle message %s: %w", env.Message.MessageId, err):
 			default:


### PR DESCRIPTION
In push mode nothing reads `Errors()`, so a failing delivery was invisible from the streamer's side (found while diagnosing a nack-looping message in prod — inflow-tech/release-notes#19). Log via slog with subscription + messageId before nacking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)