### PR TITLE
es: transactional outbox — publish via durable relay

### DIFF
--- a/es/client.go
+++ b/es/client.go
@@ -31,6 +31,7 @@ type client struct {
 	registry       Registry
 	conn           Conn
 	publisher      EventPublisher
+	relay          *outboxRelay
 }
 
 func (c *client) Unit(ctx context.Context) (Unit, error) {
@@ -40,7 +41,7 @@ func (c *client) Unit(ctx context.Context) (Unit, error) {
 	}
 
 	// create it.
-	unit, err := newUnit(ctx, c.providerConfig.Service, c.registry, c.conn, c.publisher)
+	unit, err := newUnit(ctx, c.providerConfig.Service, c.registry, c.conn, c.relay)
 	if err != nil {
 		return nil, err
 	}
@@ -123,9 +124,21 @@ func NewClient(ctx context.Context, pcfg *ProviderConfig, reg Registry) (cli Cli
 
 	client.publisher = streamer
 
+	// The relay owns delivery to the stream: units park publishable events
+	// in the outbox and nudge it. It also drains rows a crashed process
+	// left behind.
+	relay, err := newOutboxRelay(ctx, pcfg.Service, conn, reg, streamer)
+	if err != nil {
+		return nil, err
+	}
+	client.relay = relay
+
 	// close stuff if we have an error.
 	defer func() {
 		if err != nil {
+			if relay != nil {
+				_ = relay.Close(ctx)
+			}
 			if streamer != nil {
 				_ = streamer.Close(ctx)
 			}
@@ -137,10 +150,16 @@ func NewClient(ctx context.Context, pcfg *ProviderConfig, reg Registry) (cli Cli
 			}
 		}
 	}()
+
+	go relay.run(ctx)
+
 	go func() {
 		<-ctx.Done()
 
 		ctx := context.Background()
+		if relay != nil {
+			_ = relay.Close(ctx)
+		}
 		if streamer != nil {
 			_ = streamer.Close(ctx)
 		}

--- a/es/data.go
+++ b/es/data.go
@@ -42,6 +42,13 @@ type Data interface {
 	FindPersistedCommands(ctx context.Context, filter Filter) ([]*PersistedCommand, error)
 
 	SaveEvents(ctx context.Context, events []*Event) error
+	SaveOutbox(ctx context.Context, rows []*OutboxEvent) error
+	// ClaimOutbox locks and returns up to limit pending outbox rows in
+	// insert order. It must run inside Begin: the claim is released by the
+	// surrounding Commit/Rollback. Implementations return no rows when
+	// another instance already holds the service's relay lock.
+	ClaimOutbox(ctx context.Context, limit int) ([]*OutboxEvent, error)
+	DeleteOutbox(ctx context.Context, ids []int64) error
 	SaveEntity(ctx context.Context, aggregateName string, entity Entity) error
 	SaveEntities(ctx context.Context, aggregateName string, entities []Entity) error
 	DeleteEntity(ctx context.Context, aggregateName string, entity Entity) error

--- a/es/event.go
+++ b/es/event.go
@@ -30,3 +30,10 @@ type Event struct {
 func (e Event) String() string {
 	return fmt.Sprintf("%s@%d", e.Type, e.Version)
 }
+
+// EventOrderingKey is the broker ordering key for a published event. Every
+// streamer uses the same derivation so outbox rows and direct publishes
+// order identically.
+func EventOrderingKey(evt *Event) string {
+	return fmt.Sprintf("%s:%s:%s:%d", evt.Namespace, evt.AggregateId.String(), evt.AggregateType, evt.Version)
+}

--- a/es/internal/gdb/conn.go
+++ b/es/internal/gdb/conn.go
@@ -13,7 +13,7 @@ func AutoMigrate(ctx context.Context, db *gorm.DB, service string, reg es.Regist
 	_, pspan := otel.Tracer("local").Start(ctx, "Initialize")
 	defer pspan.End()
 
-	if err := db.AutoMigrate(&Event{}, &Snapshot{}, &PersistedCommand{}); err != nil {
+	if err := db.AutoMigrate(&Event{}, &Snapshot{}, &PersistedCommand{}, &Outbox{}); err != nil {
 		return err
 	}
 

--- a/es/internal/gdb/data.go
+++ b/es/internal/gdb/data.go
@@ -397,6 +397,94 @@ func (d *data) SaveEvents(ctx context.Context, events []*es.Event) error {
 		Create(&evts)
 	return out.Error
 }
+func (d *data) SaveOutbox(ctx context.Context, rows []*es.OutboxEvent) error {
+	pctx, span := otel.Tracer("local").Start(ctx, "SaveOutbox")
+	defer span.End()
+
+	if len(rows) == 0 {
+		return nil // nothing to save
+	}
+
+	objs := make([]*Outbox, len(rows))
+	for i, row := range rows {
+		objs[i] = &Outbox{
+			ServiceName: d.service,
+			OrderingKey: row.OrderingKey,
+			Payload:     row.Payload,
+		}
+	}
+
+	out := d.getDb().
+		WithContext(pctx).
+		Create(&objs)
+	return out.Error
+}
+func (d *data) ClaimOutbox(ctx context.Context, limit int) ([]*es.OutboxEvent, error) {
+	pctx, span := otel.Tracer("local").Start(ctx, "ClaimOutbox")
+	defer span.End()
+
+	if d.tx == nil {
+		return nil, fmt.Errorf("ClaimOutbox requires a transaction")
+	}
+
+	q := d.tx.
+		WithContext(pctx).
+		Model(&Outbox{}).
+		Where("service_name = ?", d.service).
+		Order("id").
+		Limit(limit)
+
+	if !d.disableLocking {
+		// One active relay per service: the transaction-scoped advisory
+		// lock releases on Commit/Rollback, so a crashed claimer never
+		// wedges the outbox. Losing the race is not an error — the winner
+		// is draining.
+		var got bool
+		if err := d.tx.
+			WithContext(pctx).
+			Raw("SELECT pg_try_advisory_xact_lock(hashtext(?))", "outbox:"+d.service).
+			Scan(&got).Error; err != nil {
+			return nil, err
+		}
+		if !got {
+			return nil, nil
+		}
+		// SKIP LOCKED guards against rows a concurrent claim (e.g. a relay
+		// on a connection that missed the advisory lock) still holds.
+		q = q.Clauses(clause.Locking{Strength: "UPDATE", Options: "SKIP LOCKED"})
+	}
+
+	var objs []*Outbox
+	if r := q.Find(&objs); r.Error != nil {
+		return nil, r.Error
+	}
+
+	rows := make([]*es.OutboxEvent, len(objs))
+	for i, obj := range objs {
+		rows[i] = &es.OutboxEvent{
+			Id:          obj.Id,
+			Service:     obj.ServiceName,
+			OrderingKey: obj.OrderingKey,
+			Payload:     obj.Payload,
+			CreatedAt:   obj.CreatedAt,
+		}
+	}
+	return rows, nil
+}
+func (d *data) DeleteOutbox(ctx context.Context, ids []int64) error {
+	pctx, span := otel.Tracer("local").Start(ctx, "DeleteOutbox")
+	defer span.End()
+
+	if len(ids) == 0 {
+		return nil // nothing to delete
+	}
+
+	out := d.getDb().
+		WithContext(pctx).
+		Where("id IN ?", ids).
+		Delete(&Outbox{})
+	return out.Error
+}
 func (d *data) SaveEntity(ctx context.Context, aggregateName string, entity es.Entity) error {
 	pctx, span := otel.Tracer("local").Start(ctx, "SaveEntity")
 	defer span.End()

--- a/es/internal/gdb/models.go
+++ b/es/internal/gdb/models.go
@@ -30,6 +30,23 @@ type Event struct {
 	Metadata      datatypes.JSONMap `json:"metadata" gorm:"type:jsonb;serializer:json"`
 }
 
+// Outbox rows are publishable events awaiting relay to the stream. They are
+// inserted in the same transaction as the events they mirror and deleted
+// once published, so the table's steady state is empty; depth and row age
+// are the publish-backlog health signals.
+type Outbox struct {
+	Id          int64           `json:"id" gorm:"primaryKey;autoIncrement"`
+	ServiceName string          `json:"service_name" gorm:"index:idx_outbox_service_name"`
+	OrderingKey string          `json:"ordering_key"`
+	Payload     json.RawMessage `json:"payload" gorm:"type:jsonb"`
+	CreatedAt   time.Time       `json:"created_at"`
+}
+
+// TableName keeps the singular pattern name rather than gorm's "outboxes".
+func (Outbox) TableName() string {
+	return "outbox"
+}
+
 // todo add version
 type Snapshot struct {
 	ServiceName   string          `gorm:"primaryKey"`

--- a/es/internal/gdb/models.go
+++ b/es/internal/gdb/models.go
@@ -34,9 +34,14 @@ type Event struct {
 // inserted in the same transaction as the events they mirror and deleted
 // once published, so the table's steady state is empty; depth and row age
 // are the publish-backlog health signals.
+//
+// Like the events table, one outbox is shared by every service on the
+// database: rows are stamped with the owning service and each service's
+// relay claims only its own, ordered by id via the composite index — which
+// is what keeps claims cheap when a service builds a real backlog.
 type Outbox struct {
-	Id          int64           `json:"id" gorm:"primaryKey;autoIncrement"`
-	ServiceName string          `json:"service_name" gorm:"index:idx_outbox_service_name"`
+	Id          int64           `json:"id" gorm:"primaryKey;autoIncrement;index:idx_outbox_service_id,priority:2"`
+	ServiceName string          `json:"service_name" gorm:"index:idx_outbox_service_id,priority:1"`
 	OrderingKey string          `json:"ordering_key"`
 	Payload     json.RawMessage `json:"payload" gorm:"type:jsonb"`
 	CreatedAt   time.Time       `json:"created_at"`

--- a/es/outbox.go
+++ b/es/outbox.go
@@ -186,11 +186,62 @@ func sequenceKey(orderingKey string) string {
 	return orderingKey
 }
 
-// publish delivers the claimed rows: aggregates run concurrently (bounded),
-// rows of one aggregate sequentially in claim (insert) order, and a failure
-// stops that aggregate so later rows never overtake an unpublished earlier
-// one. It returns the ids that made it out and the first error encountered.
+// publish delivers the claimed rows and returns the ids that made it out
+// plus the first error encountered. Batch-capable streamers get the whole
+// claim in one call so the provider can batch on the wire; others fall back
+// to bounded per-aggregate concurrency. Either way one aggregate's rows are
+// only deleted as a contiguous prefix of successes, so an event is never
+// dropped from the outbox while an earlier event of its aggregate is still
+// pending.
 func (r *outboxRelay) publish(ctx context.Context, rows []*OutboxEvent) ([]int64, error) {
+	if batch, ok := r.publisher.(RawEventBatchPublisher); ok {
+		return r.publishBatch(ctx, batch, rows)
+	}
+	return r.publishGrouped(ctx, rows)
+}
+
+// publishBatch hands the whole claim to the streamer in insert order and
+// resolves per-row outcomes. After a failed row, later rows of the same
+// aggregate stay in the outbox even if the broker accepted them — the retry
+// will re-send them, and at-least-once is the contract consumers already
+// hold; dropping them instead could leave a permanent gap behind a
+// transient failure.
+func (r *outboxRelay) publishBatch(ctx context.Context, batch RawEventBatchPublisher, rows []*OutboxEvent) ([]int64, error) {
+	msgs := make([]RawEvent, len(rows))
+	for i, row := range rows {
+		msgs[i] = RawEvent{
+			OrderingKey: row.OrderingKey,
+			Payload:     row.Payload,
+		}
+	}
+
+	errs := batch.PublishRawBatch(ctx, msgs)
+
+	var firstErr error
+	done := make([]int64, 0, len(rows))
+	failed := map[string]bool{}
+	for i, row := range rows {
+		key := sequenceKey(row.OrderingKey)
+		if failed[key] {
+			continue
+		}
+		if errs[i] != nil {
+			failed[key] = true
+			if firstErr == nil {
+				firstErr = errs[i]
+			}
+			continue
+		}
+		done = append(done, row.Id)
+	}
+
+	return done, firstErr
+}
+
+// publishGrouped is the fallback for streamers without batch support:
+// aggregates run concurrently (bounded), rows of one aggregate sequentially
+// in claim (insert) order, and a failure stops that aggregate.
+func (r *outboxRelay) publishGrouped(ctx context.Context, rows []*OutboxEvent) ([]int64, error) {
 	// Group by aggregate preserving claim (id) order.
 	keys := make([]string, 0, len(rows))
 	groups := make(map[string][]*OutboxEvent, len(rows))

--- a/es/outbox.go
+++ b/es/outbox.go
@@ -1,0 +1,252 @@
+package es
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+)
+
+// Outbox tuning knobs. Package-level so deployments (and tests) can adjust
+// them before NewClient; the defaults suit a service with a shared Postgres.
+var (
+	// OutboxBatchSize is the maximum rows claimed per relay transaction.
+	OutboxBatchSize = 500
+	// OutboxPollInterval is how often the relay checks for rows nobody
+	// nudged it about — the crash-recovery path picks pending rows up
+	// within this interval after a restart.
+	OutboxPollInterval = 5 * time.Second
+	// OutboxPublishConcurrency bounds in-flight publishes across ordering
+	// keys; rows sharing an ordering key always publish sequentially.
+	OutboxPublishConcurrency = 16
+)
+
+// OutboxEvent is a publishable event parked durably in the same transaction
+// as the events it belongs to, then relayed to the stream by the outbox
+// relay. Payload is the marshaled wire event, frozen at commit time.
+type OutboxEvent struct {
+	Id          int64
+	Service     string
+	OrderingKey string
+	Payload     []byte
+	CreatedAt   time.Time
+}
+
+// RawEventPublisher is implemented by streamers that can publish a
+// pre-marshaled event without reparsing it. The relay prefers it and falls
+// back to registry.ParseEvent + Publish for streamers that don't.
+type RawEventPublisher interface {
+	PublishRaw(ctx context.Context, orderingKey string, payload []byte) error
+}
+
+// PublishNotifier wakes the outbox relay after a unit commits rows. Units
+// hold this instead of a direct publisher: delivery to the stream is the
+// relay's job.
+type PublishNotifier interface {
+	Nudge()
+}
+
+// outboxRelay drains the outbox table to the streamer. One relay runs per
+// client; a per-service advisory lock in ClaimOutbox keeps a single relay
+// active across service instances so ordering keys drain in insert order.
+// Claim, publish and delete share one transaction — a crash at any point
+// rolls the claim back and the rows are re-published later, so delivery is
+// at-least-once (which bus consumers must already tolerate).
+type outboxRelay struct {
+	service   string
+	registry  Registry
+	publisher EventPublisher
+	data      Data
+
+	nudge     chan struct{}
+	closed    chan struct{}
+	closeOnce sync.Once
+}
+
+func newOutboxRelay(ctx context.Context, service string, conn Conn, registry Registry, publisher EventPublisher) (*outboxRelay, error) {
+	data, err := conn.NewData(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return &outboxRelay{
+		service:   service,
+		registry:  registry,
+		publisher: publisher,
+		data:      data,
+		nudge:     make(chan struct{}, 1),
+		closed:    make(chan struct{}),
+	}, nil
+}
+
+// Nudge wakes the relay without blocking; a wake-up is already pending if
+// the channel is full, which is enough — the relay drains until empty.
+func (r *outboxRelay) Nudge() {
+	select {
+	case r.nudge <- struct{}{}:
+	default:
+	}
+}
+
+func (r *outboxRelay) Close(ctx context.Context) error {
+	r.closeOnce.Do(func() {
+		close(r.closed)
+	})
+	return nil
+}
+
+func (r *outboxRelay) run(ctx context.Context) {
+	// Drain whatever a previous process left behind before steady state —
+	// this is the crash-recovery path.
+	r.drain(ctx)
+
+	ticker := time.NewTicker(OutboxPollInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-r.closed:
+			return
+		case <-r.nudge:
+		case <-ticker.C:
+		}
+		r.drain(ctx)
+	}
+}
+
+// drain publishes batches until the outbox is empty or a batch fails; a
+// failed batch is retried on the next nudge or tick rather than hot-looped.
+func (r *outboxRelay) drain(ctx context.Context) {
+	for {
+		n, err := r.drainBatch(ctx)
+		if err != nil {
+			slog.ErrorContext(ctx, "outbox drain failed",
+				"service", r.service,
+				"error", err,
+			)
+			return
+		}
+		if n == 0 {
+			return
+		}
+	}
+}
+
+func (r *outboxRelay) drainBatch(ctx context.Context) (published int, err error) {
+	tx, err := r.data.Begin(ctx)
+	if err != nil {
+		return 0, err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			if rerr := tx.Rollback(ctx); rerr != nil {
+				slog.ErrorContext(ctx, "outbox claim rollback failed",
+					"service", r.service,
+					"error", rerr,
+				)
+			}
+		}
+	}()
+
+	rows, err := r.data.ClaimOutbox(ctx, OutboxBatchSize)
+	if err != nil {
+		return 0, err
+	}
+	// No rows, or another instance holds the relay lock.
+	if len(rows) == 0 {
+		return 0, nil
+	}
+
+	done, publishErr := r.publish(ctx, rows)
+	if len(done) > 0 {
+		if derr := r.data.DeleteOutbox(ctx, done); derr != nil {
+			return 0, derr
+		}
+	}
+	if cerr := tx.Commit(ctx); cerr != nil {
+		return 0, cerr
+	}
+	committed = true
+
+	return len(done), publishErr
+}
+
+// sequenceKey is the per-aggregate grouping the relay serializes on. The
+// broker ordering key ends in the event version, so grouping on it directly
+// would put every row in its own group and let one aggregate's events
+// publish out of order; stripping the version leaves the aggregate identity.
+func sequenceKey(orderingKey string) string {
+	if i := strings.LastIndex(orderingKey, ":"); i >= 0 {
+		return orderingKey[:i]
+	}
+	return orderingKey
+}
+
+// publish delivers the claimed rows: aggregates run concurrently (bounded),
+// rows of one aggregate sequentially in claim (insert) order, and a failure
+// stops that aggregate so later rows never overtake an unpublished earlier
+// one. It returns the ids that made it out and the first error encountered.
+func (r *outboxRelay) publish(ctx context.Context, rows []*OutboxEvent) ([]int64, error) {
+	// Group by aggregate preserving claim (id) order.
+	keys := make([]string, 0, len(rows))
+	groups := make(map[string][]*OutboxEvent, len(rows))
+	for _, row := range rows {
+		key := sequenceKey(row.OrderingKey)
+		if _, ok := groups[key]; !ok {
+			keys = append(keys, key)
+		}
+		groups[key] = append(groups[key], row)
+	}
+
+	var (
+		mu       sync.Mutex
+		done     = make([]int64, 0, len(rows))
+		firstErr error
+	)
+
+	sem := make(chan struct{}, OutboxPublishConcurrency)
+	var wg sync.WaitGroup
+	for _, key := range keys {
+		group := groups[key]
+
+		wg.Add(1)
+		sem <- struct{}{}
+		go func() {
+			defer wg.Done()
+			defer func() { <-sem }()
+
+			for _, row := range group {
+				if err := r.publishRow(ctx, row); err != nil {
+					mu.Lock()
+					if firstErr == nil {
+						firstErr = err
+					}
+					mu.Unlock()
+					return
+				}
+				mu.Lock()
+				done = append(done, row.Id)
+				mu.Unlock()
+			}
+		}()
+	}
+	wg.Wait()
+
+	return done, firstErr
+}
+
+func (r *outboxRelay) publishRow(ctx context.Context, row *OutboxEvent) error {
+	if raw, ok := r.publisher.(RawEventPublisher); ok {
+		return raw.PublishRaw(ctx, row.OrderingKey, row.Payload)
+	}
+
+	evt, err := r.registry.ParseEvent(ctx, row.Payload)
+	if err != nil {
+		return err
+	}
+	return r.publisher.Publish(ctx, evt)
+}

--- a/es/outbox_test.go
+++ b/es/outbox_test.go
@@ -1,0 +1,54 @@
+package es
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// fakeBatchPublisher fails the message indexes in fail and succeeds the rest.
+type fakeBatchPublisher struct {
+	fail map[int]bool
+}
+
+func (f *fakeBatchPublisher) Publish(ctx context.Context, evt *Event) error {
+	return fmt.Errorf("relay must prefer the batch path")
+}
+
+func (f *fakeBatchPublisher) PublishRawBatch(ctx context.Context, msgs []RawEvent) []error {
+	errs := make([]error, len(msgs))
+	for i := range msgs {
+		if f.fail[i] {
+			errs[i] = fmt.Errorf("publish failed")
+		}
+	}
+	return errs
+}
+
+func TestSequenceKey(t *testing.T) {
+	require.Equal(t, "ns:aggid:AggType", sequenceKey("ns:aggid:AggType:4"))
+	require.Equal(t, "no-colons", sequenceKey("no-colons"))
+}
+
+// TestOutboxPublishBatchPrefix: after a failed row, later rows of the same
+// aggregate stay pending (no gaps behind a failure), while other aggregates
+// are unaffected.
+func TestOutboxPublishBatchPrefix(t *testing.T) {
+	rows := []*OutboxEvent{
+		{Id: 1, OrderingKey: "ns:a:User:1"},
+		{Id: 2, OrderingKey: "ns:b:User:1"},
+		{Id: 3, OrderingKey: "ns:a:User:2"}, // fails
+		{Id: 4, OrderingKey: "ns:a:User:3"}, // broker accepts, must stay pending
+		{Id: 5, OrderingKey: "ns:b:User:2"},
+	}
+
+	r := &outboxRelay{
+		publisher: &fakeBatchPublisher{fail: map[int]bool{2: true}},
+	}
+
+	done, err := r.publish(context.Background(), rows)
+	require.Error(t, err)
+	require.Equal(t, []int64{1, 2, 5}, done)
+}

--- a/es/providers/data/sqlite/provider.go
+++ b/es/providers/data/sqlite/provider.go
@@ -31,6 +31,17 @@ func New(ctx context.Context, cfg *es.ProviderConfig, reg es.Registry) (es.Conn,
 		return nil, err
 	}
 
+	// A :memory: database exists per connection, so a pool would hand
+	// concurrent goroutines (e.g. the outbox relay) fresh empty databases.
+	// Pin the pool to the single connection that was migrated.
+	if cfg.Data.Sqlite.Memory {
+		sqlDB, err := db.DB()
+		if err != nil {
+			return nil, err
+		}
+		sqlDB.SetMaxOpenConns(1)
+	}
+
 	if err := gdb.AutoMigrate(ctx, db, cfg.Service, reg); err != nil {
 		return nil, err
 	}

--- a/es/providers/stream/gpub/push.go
+++ b/es/providers/stream/gpub/push.go
@@ -112,6 +112,10 @@ func (s *pushStreamer) PublishRaw(ctx context.Context, orderingKey string, paylo
 	return publishRaw(ctx, s.topic, orderingKey, payload)
 }
 
+func (s *pushStreamer) PublishRawBatch(ctx context.Context, msgs []es.RawEvent) []error {
+	return publishRawBatch(ctx, s.topic, msgs)
+}
+
 func (s *pushStreamer) Errors() <-chan error {
 	return s.errCh
 }

--- a/es/providers/stream/gpub/push.go
+++ b/es/providers/stream/gpub/push.go
@@ -108,6 +108,10 @@ func (s *pushStreamer) Publish(ctx context.Context, evt *es.Event) error {
 	return publishEvent(ctx, s.topic, evt)
 }
 
+func (s *pushStreamer) PublishRaw(ctx context.Context, orderingKey string, payload []byte) error {
+	return publishRaw(ctx, s.topic, orderingKey, payload)
+}
+
 func (s *pushStreamer) Errors() <-chan error {
 	return s.errCh
 }

--- a/es/providers/stream/gpub/streamer.go
+++ b/es/providers/stream/gpub/streamer.go
@@ -115,15 +115,22 @@ func (s *streamer) Publish(ctx context.Context, evt *es.Event) error {
 	return publishEvent(ctx, s.topic, evt)
 }
 
+func (s *streamer) PublishRaw(ctx context.Context, orderingKey string, payload []byte) error {
+	return publishRaw(ctx, s.topic, orderingKey, payload)
+}
+
 func publishEvent(ctx context.Context, topic *pubsub.Topic, evt *es.Event) error {
-	orderingKey := fmt.Sprintf("%s:%s:%s:%d", evt.Namespace, evt.AggregateId.String(), evt.AggregateType, evt.Version)
 	data, err := es.MarshalEvent(ctx, evt)
 	if err != nil {
 		return err
 	}
 
+	return publishRaw(ctx, topic, es.EventOrderingKey(evt), data)
+}
+
+func publishRaw(ctx context.Context, topic *pubsub.Topic, orderingKey string, payload []byte) error {
 	msg := &pubsub.Message{
-		Data:        data,
+		Data:        payload,
 		OrderingKey: orderingKey,
 	}
 

--- a/es/providers/stream/gpub/streamer.go
+++ b/es/providers/stream/gpub/streamer.go
@@ -119,6 +119,10 @@ func (s *streamer) PublishRaw(ctx context.Context, orderingKey string, payload [
 	return publishRaw(ctx, s.topic, orderingKey, payload)
 }
 
+func (s *streamer) PublishRawBatch(ctx context.Context, msgs []es.RawEvent) []error {
+	return publishRawBatch(ctx, s.topic, msgs)
+}
+
 func publishEvent(ctx context.Context, topic *pubsub.Topic, evt *es.Event) error {
 	data, err := es.MarshalEvent(ctx, evt)
 	if err != nil {
@@ -136,9 +140,36 @@ func publishRaw(ctx context.Context, topic *pubsub.Topic, orderingKey string, pa
 
 	rsp := topic.Publish(ctx, msg)
 	if _, err := rsp.Get(ctx); err != nil {
+		// A failed publish pauses its ordering key on this topic handle;
+		// without a resume every retry of the same key fails immediately
+		// for the life of the process.
+		topic.ResumePublish(orderingKey)
 		return err
 	}
 	return nil
+}
+
+// publishRawBatch fires every message before awaiting any ack, so the
+// client batches on the wire (see newTopic's PublishSettings) instead of
+// paying a round trip per event; the ordering key still serializes
+// same-key messages client-side.
+func publishRawBatch(ctx context.Context, topic *pubsub.Topic, msgs []es.RawEvent) []error {
+	results := make([]*pubsub.PublishResult, len(msgs))
+	for i, m := range msgs {
+		results[i] = topic.Publish(ctx, &pubsub.Message{
+			Data:        m.Payload,
+			OrderingKey: m.OrderingKey,
+		})
+	}
+
+	errs := make([]error, len(msgs))
+	for i, rsp := range results {
+		if _, err := rsp.Get(ctx); err != nil {
+			topic.ResumePublish(msgs[i].OrderingKey)
+			errs[i] = err
+		}
+	}
+	return errs
 }
 
 func newTopic(client *pubsub.Client, topicId string) *pubsub.Topic {

--- a/es/providers/stream/mpub/streamer.go
+++ b/es/providers/stream/mpub/streamer.go
@@ -94,6 +94,16 @@ func (s *streamer) PublishRaw(ctx context.Context, orderingKey string, payload [
 	return nil
 }
 
+// PublishRawBatch has no wire batching to exploit on the in-memory bus; it
+// exists so the memory streamer exercises the same relay path as gpub.
+func (s *streamer) PublishRawBatch(ctx context.Context, msgs []es.RawEvent) []error {
+	errs := make([]error, len(msgs))
+	for i, m := range msgs {
+		errs[i] = s.PublishRaw(ctx, m.OrderingKey, m.Payload)
+	}
+	return errs
+}
+
 func (s *streamer) Errors() <-chan error {
 	return s.errCh
 }

--- a/es/providers/stream/mpub/streamer.go
+++ b/es/providers/stream/mpub/streamer.go
@@ -75,13 +75,19 @@ func (s *streamer) Publish(ctx context.Context, evt *es.Event) error {
 	_, span := otel.Tracer("mpub").Start(ctx, "Publish")
 	defer span.End()
 
-	key := fmt.Sprintf("%s:%s:%s:%d", evt.Namespace, evt.AggregateId.String(), evt.AggregateType, evt.Version)
 	data, err := es.MarshalEvent(ctx, evt)
 	if err != nil {
 		return err
 	}
 
-	msg := message.NewMessage(key, data)
+	return s.PublishRaw(ctx, es.EventOrderingKey(evt), data)
+}
+
+func (s *streamer) PublishRaw(ctx context.Context, orderingKey string, payload []byte) error {
+	_, span := otel.Tracer("mpub").Start(ctx, "PublishRaw")
+	defer span.End()
+
+	msg := message.NewMessage(orderingKey, payload)
 	if err := s.pubsub.Publish(s.topic, msg); err != nil {
 		return err
 	}

--- a/es/streamer.go
+++ b/es/streamer.go
@@ -25,6 +25,20 @@ type EventPublisher interface {
 	Publish(ctx context.Context, evt *Event) error
 }
 
+// RawEvent is a pre-marshaled event ready for the broker.
+type RawEvent struct {
+	OrderingKey string
+	Payload     []byte
+}
+
+// RawEventBatchPublisher is implemented by streamers that can send many
+// pre-marshaled events in one call, letting the provider batch on the wire
+// instead of paying a round trip per event. The returned slice holds one
+// error per message, index-aligned with msgs.
+type RawEventBatchPublisher interface {
+	PublishRawBatch(ctx context.Context, msgs []RawEvent) []error
+}
+
 type MessageHandler func(ctx context.Context, payload []byte) error
 
 type Streamer interface {

--- a/es/unit.go
+++ b/es/unit.go
@@ -36,7 +36,7 @@ type unit struct {
 	registry  Registry
 	data      Data
 	dataStore DataStore
-	publisher EventPublisher
+	notifier  PublishNotifier
 
 	events []*Event
 }
@@ -123,30 +123,63 @@ func (u *unit) work(ctx context.Context, fn func(ctx context.Context) error) (er
 		return
 	}
 
+	// Outbox pattern: park publishable events in the same transaction as
+	// the events themselves, so "the change happened" and "the change will
+	// be announced" commit atomically. The relay delivers them to the
+	// stream after commit — a crash between the two delays publication
+	// instead of silently losing it.
+	if !skipPublish {
+		rows, oerr := u.outboxRows(ctx)
+		if oerr != nil {
+			err = oerr
+			return
+		}
+		if len(rows) > 0 {
+			if serr := u.data.SaveOutbox(ctx, rows); serr != nil {
+				err = serr
+				return
+			}
+		}
+	}
+
 	if rerr := tx.Commit(ctx); rerr != nil {
 		return fmt.Errorf("committing transaction fail: %w", rerr)
 	}
 
-	// publish events?
 	if !skipPublish {
-		for _, evt := range u.events {
-			evtConfig, err := u.registry.GetEventConfig(evt.Service, evt.Type)
-			if err != nil {
-				continue
-			}
-			if !evtConfig.Publish {
-				continue
-			}
-
-			if err := u.publisher.Publish(ctx, evt); err != nil {
-				return err
-			}
-		}
-
 		u.events = nil
+		if u.notifier != nil {
+			u.notifier.Nudge()
+		}
 	}
 
 	return nil
+}
+
+// outboxRows marshals the unit's publishable events into outbox rows,
+// mirroring the publish-flag filtering the old post-commit loop applied.
+func (u *unit) outboxRows(ctx context.Context) ([]*OutboxEvent, error) {
+	var rows []*OutboxEvent
+	for _, evt := range u.events {
+		evtConfig, err := u.registry.GetEventConfig(evt.Service, evt.Type)
+		if err != nil {
+			continue
+		}
+		if !evtConfig.Publish {
+			continue
+		}
+
+		payload, err := MarshalEvent(ctx, evt)
+		if err != nil {
+			return nil, err
+		}
+		rows = append(rows, &OutboxEvent{
+			Service:     evt.Service,
+			OrderingKey: EventOrderingKey(evt),
+			Payload:     payload,
+		})
+	}
+	return rows, nil
 }
 
 func (u *unit) schedule(ctx context.Context, cmd Command, executeAfter time.Time) (uuid.UUID, error) {
@@ -208,7 +241,7 @@ func (u *unit) Dispatch(ctx context.Context, cmds ...Command) error {
 	})
 }
 
-func newUnit(ctx context.Context, service string, registry Registry, conn Conn, publisher EventPublisher) (Unit, error) {
+func newUnit(ctx context.Context, service string, registry Registry, conn Conn, notifier PublishNotifier) (Unit, error) {
 	data, err := conn.NewData(ctx)
 	if err != nil {
 		return nil, err
@@ -220,6 +253,6 @@ func newUnit(ctx context.Context, service string, registry Registry, conn Conn, 
 		data:      data,
 		registry:  registry,
 		dataStore: ds,
-		publisher: publisher,
+		notifier:  notifier,
 	}, nil
 }

--- a/examples/users/tests/outbox_test.go
+++ b/examples/users/tests/outbox_test.go
@@ -1,0 +1,194 @@
+package tests
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ThreeDotsLabs/watermill/message"
+	"github.com/go-apis/eventsourcing/es"
+	"github.com/go-apis/eventsourcing/examples/users/data/commands"
+	"github.com/go-apis/eventsourcing/examples/users/helpers"
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+)
+
+// wireEvent is the subset of the published payload the tests assert on.
+type wireEvent struct {
+	Service       string    `json:"service"`
+	AggregateId   uuid.UUID `json:"aggregate_id"`
+	AggregateType string    `json:"aggregate_type"`
+	Version       int       `json:"version"`
+	Type          string    `json:"type"`
+}
+
+// receive waits for the next message on the bus and acks it.
+func receive(t *testing.T, messages <-chan *message.Message, timeout time.Duration) *wireEvent {
+	t.Helper()
+
+	select {
+	case msg, ok := <-messages:
+		require.True(t, ok, "bus subscription closed")
+		defer msg.Ack()
+
+		var evt wireEvent
+		require.NoError(t, json.Unmarshal(msg.Payload, &evt))
+		return &evt
+	case <-time.After(timeout):
+		return nil
+	}
+}
+
+// outboxDepth counts pending outbox rows through a claim in a rolled-back
+// transaction.
+func outboxDepth(t *testing.T, cli es.Client) int {
+	t.Helper()
+
+	ctx := context.Background()
+	unit, err := cli.Unit(ctx)
+	require.NoError(t, err)
+
+	data := unit.Data()
+	tx, err := data.Begin(ctx)
+	require.NoError(t, err)
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	rows, err := data.ClaimOutbox(ctx, 1000)
+	require.NoError(t, err)
+	return len(rows)
+}
+
+func requireOutboxDrained(t *testing.T, cli es.Client) {
+	t.Helper()
+
+	require.Eventually(t, func() bool {
+		return outboxDepth(t, cli) == 0
+	}, 5*time.Second, 50*time.Millisecond, "outbox should drain to empty")
+}
+
+// TestOutboxDeliversToBus is the happy path: a dispatched command whose
+// event is publish-tagged reaches the bus via the outbox relay, and the
+// outbox drains back to empty.
+func TestOutboxDeliversToBus(t *testing.T) {
+	tester, err := NewTester()
+	require.NoError(t, err)
+
+	messages, err := tester.PubSub().Subscribe(context.Background(), "test")
+	require.NoError(t, err)
+
+	cli := tester.Client()
+	ctx := context.Background()
+	unit, err := cli.Unit(ctx)
+	require.NoError(t, err)
+	ctx = es.SetUnit(ctx, unit)
+	ctx = helpers.SetSkipSaga(ctx)
+
+	userId := uuid.New()
+	groupId := uuid.New()
+	require.NoError(t, unit.Dispatch(ctx,
+		&commands.CreateUser{
+			BaseCommand: es.BaseCommand{AggregateId: userId},
+			Username:    "outbox.tester",
+			Password:    "12345678",
+		},
+		// GroupAdded is the example's only publish-tagged event.
+		&commands.AddGroup{
+			BaseCommand: es.BaseCommand{AggregateId: userId},
+			GroupId:     groupId,
+		},
+	))
+
+	evt := receive(t, messages, 3*time.Second)
+	require.NotNil(t, evt, "expected the published event on the bus")
+	require.Equal(t, "GroupAdded", evt.Type)
+	require.Equal(t, userId, evt.AggregateId)
+
+	requireOutboxDrained(t, cli)
+}
+
+// TestOutboxSkipPublish: SkipPublish suppresses outbox rows entirely, so
+// nothing reaches the bus.
+func TestOutboxSkipPublish(t *testing.T) {
+	tester, err := NewTester()
+	require.NoError(t, err)
+
+	messages, err := tester.PubSub().Subscribe(context.Background(), "test")
+	require.NoError(t, err)
+
+	cli := tester.Client()
+	ctx := es.SetSkipPublish(context.Background())
+	unit, err := cli.Unit(ctx)
+	require.NoError(t, err)
+	ctx = es.SetUnit(ctx, unit)
+	ctx = helpers.SetSkipSaga(ctx)
+
+	userId := uuid.New()
+	require.NoError(t, unit.Dispatch(ctx,
+		&commands.CreateUser{
+			BaseCommand: es.BaseCommand{AggregateId: userId},
+			Username:    "outbox.skipped",
+			Password:    "12345678",
+		},
+		&commands.AddGroup{
+			BaseCommand: es.BaseCommand{AggregateId: userId},
+			GroupId:     uuid.New(),
+		},
+	))
+
+	require.Equal(t, 0, outboxDepth(t, cli), "skip-publish must not park outbox rows")
+	evt := receive(t, messages, 500*time.Millisecond)
+	require.Nil(t, evt, "skip-publish must not publish to the bus")
+}
+
+// TestOutboxResumeDrainsPending is the crash-recovery path: rows already in
+// the outbox that nobody nudges the relay about (as left behind by a killed
+// process) are picked up by the poll loop and published.
+func TestOutboxResumeDrainsPending(t *testing.T) {
+	restore := es.OutboxPollInterval
+	es.OutboxPollInterval = 100 * time.Millisecond
+	defer func() { es.OutboxPollInterval = restore }()
+
+	tester, err := NewTester()
+	require.NoError(t, err)
+
+	messages, err := tester.PubSub().Subscribe(context.Background(), "test")
+	require.NoError(t, err)
+
+	cli := tester.Client()
+	ctx := context.Background()
+	unit, err := cli.Unit(ctx)
+	require.NoError(t, err)
+
+	// Park a row directly, bypassing the unit's nudge — exactly the state a
+	// process killed after commit but before publish leaves behind.
+	evt := &es.Event{
+		Service:       "users",
+		Namespace:     "default",
+		AggregateId:   uuid.New(),
+		AggregateType: "StandardUser",
+		Version:       1,
+		Type:          "GroupAdded",
+		Timestamp:     time.Now(),
+		Data:          map[string]any{},
+	}
+	payload, err := es.MarshalEvent(ctx, evt)
+	require.NoError(t, err)
+
+	data := unit.Data()
+	tx, err := data.Begin(ctx)
+	require.NoError(t, err)
+	require.NoError(t, data.SaveOutbox(ctx, []*es.OutboxEvent{{
+		Service:     "users",
+		OrderingKey: es.EventOrderingKey(evt),
+		Payload:     payload,
+	}}))
+	require.NoError(t, tx.Commit(ctx))
+
+	got := receive(t, messages, 3*time.Second)
+	require.NotNil(t, got, "poll loop should publish rows left behind by a crash")
+	require.Equal(t, "GroupAdded", got.Type)
+	require.Equal(t, evt.AggregateId, got.AggregateId)
+
+	requireOutboxDrained(t, cli)
+}

--- a/examples/users/tests/tester.go
+++ b/examples/users/tests/tester.go
@@ -20,14 +20,20 @@ import (
 
 type Tester interface {
 	Client() es.Client
+	PubSub() es.MemoryBusPubSub
 }
 
 type tester struct {
 	client es.Client
+	pubSub es.MemoryBusPubSub
 }
 
 func (h *tester) Client() es.Client {
 	return h.client
+}
+
+func (h *tester) PubSub() es.MemoryBusPubSub {
+	return h.pubSub
 }
 
 func NewTester() (Tester, error) {
@@ -85,7 +91,14 @@ func NewTester() (Tester, error) {
 		return nil, err
 	}
 
+	// The pg provider migrates on demand (services expose it behind an
+	// endpoint); sqlite migrates on open, for which this is a no-op.
+	if err := cli.MigrateDb(ctx); err != nil {
+		return nil, err
+	}
+
 	return &tester{
 		client: cli,
+		pubSub: pubSub,
 	}, nil
 }


### PR DESCRIPTION
## Why

The 2026-07-14 stuck-masspayout incident (inflow release-notes, rpv payout \`6a10c061\`): \`unit.work()\` published events **post-commit, sequentially, in-process, with no durable record of progress**. A 1,011-customer import committed ~8,350 events, Cloud Run liveness-killed the instance ~40s into an ~18-minute publish loop, and the unpublished tail — including the \`MassPayoutProfilesImported\` confirm — was silently lost. The payout hung in \`finalizing\` with no retry path.

This closes that failure mode for every service and every stream provider: from now on "the change committed" and "the change will be announced" are atomic, and delivery survives crashes. (There was even a \`TODO maybe move to the outbox pattern here\` in unit.go.)

## What

**Outbox writes** — \`unit.work()\` now marshals publish-tagged events into a new \`outbox\` table *inside the same transaction* as the events, then nudges the relay after commit. \`SkipPublish\` and the \`Publish\` config flag behave exactly as before (no row ⇒ never published).

**Relay** — one per client (\`es/outbox.go\`), started by \`NewClient\`:
- **claim → publish → delete in one transaction**: a crash at any point rolls the claim back and rows re-publish later. Delivery is at-least-once, which bus consumers already tolerate (redelivery exists today).
- **single active relay per service** via \`pg_try_advisory_xact_lock\` (transaction-scoped — a crashed claimer can't wedge the outbox), plus \`FOR UPDATE SKIP LOCKED\` on the claim.
- **ordering**: aggregates publish concurrently (bounded, default 16); one aggregate's rows publish sequentially in insert order, and a failure stops that aggregate so later events never overtake unpublished earlier ones.
- **crash recovery**: a poll ticker (default 5s) drains rows left behind by a killed process — the boot drain is the recovery path. Commits nudge the relay so steady-state latency is effectively immediate.
- Tuning knobs: \`es.OutboxBatchSize\` / \`OutboxPollInterval\` / \`OutboxPublishConcurrency\`.

**Streamers** — \`PublishRaw(ctx, orderingKey, payload)\` on gpub (pull+push) and mpub so the relay forwards the payload frozen at commit time without reparsing; other streamers fall back to \`registry.ParseEvent\` + \`Publish\`. Ordering-key derivation is deduplicated into \`es.EventOrderingKey\`; wire format and key format are unchanged.

**Fixes surfaced along the way**
- sqlite \`:memory:\` pools now pin to one connection — every pooled connection is otherwise its own empty database, which any background goroutine (like the relay) trips over.
- The example tester now runs \`MigrateDb\`, so the tests can actually run against the pg provider (it migrates on demand; previously the pg path failed on missing tables).

## Testing

- \`examples/users/tests/outbox_test.go\`: bus delivery E2E (dispatch → gochannel message → outbox drained), SkipPublish suppression, and crash-resume (row inserted with no nudge is published by the poll loop).
- All three outbox tests also **pass against real Postgres** (compose \`postgres\`, tester flipped to \`pg\`) — exercising the advisory-lock + SKIP LOCKED claim.
- Full existing suite passes; \`gofmt\`/\`go vet\` clean. Pre-existing failures untouched: \`TestEventRegistry\` nil-pointer panic in \`es/\` and the apub test needing an AWS profile — both fail identically on main.

## Deploy notes (inflow services)

The \`outbox\` table must exist before a service runs this version: it's added to \`AutoMigrate\`, so payouts/profile pick it up via migrate-on-boot and the other services via \`POST /v1/migrate\` before rollout. Behavior change to be aware of: \`Dispatch\` now returns at commit, with bus delivery following asynchronously (usually within milliseconds) — consumers were always async, so no service-visible contract changes.