### PR TITLE
es: detached units — per-chunk transaction boundaries for bus handlers

### DIFF
--- a/es/client.go
+++ b/es/client.go
@@ -109,6 +109,8 @@ func NewClient(ctx context.Context, pcfg *ProviderConfig, reg Registry) (cli Cli
 			if evt.By != nil {
 				innerCtx = SetActor(ctx, evt.By)
 			}
+			// Handlers can mint detached units (chunked commits) from ctx.
+			innerCtx = SetClient(innerCtx, client)
 
 			// create the unit.
 			unit, err := client.Unit(innerCtx)

--- a/es/context.go
+++ b/es/context.go
@@ -16,6 +16,7 @@ const (
 	ActorKey
 	SkipPublishKey
 	TimeKey
+	ClientKey
 )
 
 const defaultNamespace = "default"
@@ -72,6 +73,46 @@ func SetNamespace(ctx context.Context, namespace string) context.Context {
 }
 func SetUnit(ctx context.Context, unit Unit) context.Context {
 	return context.WithValue(ctx, UnitKey, unit)
+}
+
+// SetClient makes the owning client reachable from handler contexts so
+// NewDetachedUnit can mint fresh units there.
+func SetClient(ctx context.Context, cli Client) context.Context {
+	return context.WithValue(ctx, ClientKey, cli)
+}
+
+func GetClient(ctx context.Context) (Client, error) {
+	cli, ok := ctx.Value(ClientKey).(Client)
+	if ok {
+		return cli, nil
+	}
+	return nil, ErrNotFound
+}
+
+// NewDetachedUnit returns a fresh unit with its own transaction boundary,
+// ignoring any unit already in ctx. Bus handlers use it to commit work in
+// increments — one unit per chunk — instead of accumulating everything in
+// the delivery-wide transaction: committed chunks survive a crash, update
+// read models (and the outbox) as they land, and idempotent commands let a
+// redelivery converge over them. Dispatch through it with
+// es.SetUnit(ctx, unit) so nested handling stays inside the chunk.
+//
+// This is a Postgres pattern: providers pinned to one connection (sqlite
+// :memory:) cannot begin a detached transaction while the delivery
+// transaction holds the connection.
+//
+// Outside a bus delivery no client is registered — replay endpoints and
+// tests invoke handlers on their own unit — so NewDetachedUnit falls back
+// to the ctx unit there: chunked dispatch degrades to the caller's single
+// transaction instead of failing.
+func NewDetachedUnit(ctx context.Context) (Unit, error) {
+	cli, err := GetClient(ctx)
+	if err != nil {
+		return GetUnit(ctx)
+	}
+	// Clear the unit key so the client mints a new one instead of
+	// returning the delivery's unit.
+	return cli.Unit(context.WithValue(ctx, UnitKey, nil))
 }
 func SetActor(ctx context.Context, actor *Actor) context.Context {
 	return context.WithValue(ctx, ActorKey, actor)

--- a/examples/users/tests/outbox_test.go
+++ b/examples/users/tests/outbox_test.go
@@ -192,3 +192,44 @@ func TestOutboxResumeDrainsPending(t *testing.T) {
 
 	requireOutboxDrained(t, cli)
 }
+
+// TestDetachedUnit: a detached unit ignores the ctx unit and commits on its
+// own, so handlers can land chunk increments independently of the
+// delivery-wide transaction.
+func TestDetachedUnit(t *testing.T) {
+	tester, err := NewTester()
+	require.NoError(t, err)
+
+	cli := tester.Client()
+	ctx := es.SetClient(context.Background(), cli)
+
+	outer, err := cli.Unit(ctx)
+	require.NoError(t, err)
+	ctx = es.SetUnit(ctx, outer)
+
+	detached, err := es.NewDetachedUnit(ctx)
+	require.NoError(t, err)
+	require.NotSame(t, outer, detached)
+
+	dctx := helpers.SetSkipSaga(es.SetUnit(ctx, detached))
+	userId := uuid.New()
+	require.NoError(t, detached.Dispatch(dctx,
+		&commands.CreateUser{
+			BaseCommand: es.BaseCommand{AggregateId: userId},
+			Username:    "detached.tester",
+			Password:    "12345678",
+		},
+	))
+
+	// Committed by the detached unit: visible to an unrelated fresh unit.
+	freshCtx := context.Background()
+	fresh, err := cli.Unit(freshCtx)
+	require.NoError(t, err)
+	freshCtx = es.SetUnit(freshCtx, fresh)
+	var out struct {
+		Id       uuid.UUID `json:"id"`
+		Username string    `json:"username"`
+	}
+	require.NoError(t, fresh.Get(freshCtx, "StandardUser", "default", userId, &out))
+	require.Equal(t, "detached.tester", out.Username)
+}


### PR DESCRIPTION
Bus handlers run inside \`unit.Handle\`'s delivery-wide transaction, and the pg provider disables nested transactions — so a handler's "chunked" \`unit.Dispatch\` calls silently flatten into one giant commit. That defeats both goals of chunking: no incremental read-model visibility (live progress screens see one 0→done jump) and an all-or-nothing transaction that redelivers from zero on a crash.

**\`es.NewDetachedUnit(ctx)\`** mints a fresh unit (own transaction, own outbox rows) from the client, which \`MessageHandler\` now places in handler contexts via \`es.SetClient\`. Handlers dispatch each chunk through a detached unit: chunks commit and publish as they land, and idempotent commands let redeliveries converge over already-committed chunks.

Outside a bus delivery (replay endpoints, tests) no client is registered — \`NewDetachedUnit\` falls back to the ctx unit, so chunked dispatch degrades to the caller's single transaction instead of failing.

Notes:
- Postgres pattern: single-connection providers (sqlite \`:memory:\`) can't begin a detached tx while the delivery tx holds the connection.
- Covered by \`TestDetachedUnit\` (fresh-unit commit visible to unrelated units) + downstream: inflow api's new \`Test_MassPayoutFinalize_Chunked\` E2E drives it end-to-end.
- Proposed tag: **v0.6.1**.