### PR TITLE
es: order event replay by version in loadSourced

### DIFF
--- a/es/datastore.go
+++ b/es/datastore.go
@@ -99,6 +99,10 @@ func (s *dataStore) loadSourced(ctx context.Context, entityConfig *EntityConfig,
 				Args:   aggregate.GetVersion(),
 			},
 		},
+		// Replay order must not depend on the query plan: an index that
+		// returns rows in another order (e.g. timestamp DESC) would rebuild
+		// state from events applied backwards.
+		Order: []Order{{Expression: "version", Direction: OrderAsc}},
 	}
 	// load up the events from the DB.
 	originalEvents, err := s.data.FindEvents(ctx, eventFilter)


### PR DESCRIPTION
## Problem

`loadSourced` fetches an aggregate's events with no `ORDER BY` and JSON-merges them in whatever order the rows come back. That order silently depends on the Postgres query plan.

In prod, a hand-added index `idx_events_namespace_aggtype_timestamp_desc (namespace, aggregate_type, timestamp DESC)` started winning the plan for pinpoint aggregate loads, so events replayed **newest-first**. Concrete failure (2026-07-16): a removed `NamespaceMember` replayed as `active` (the v1 `Added` event was merged last), so re-adding the member failed with `member already exists` while the projection row correctly said `removed`.

## Fix

Pass an explicit `Order: version ASC` in the replay query's filter so rebuilt state never depends on the access path. One-liner; `FindEvents` already supports `filter.Order`.

## Verification

Reproduced against prod data: the pkey plan returns v1,v2 (correct), the timestamp-DESC index plan returned v2,v1 (backwards). The offending prod index has been dropped as an emergency mitigation; this change makes any future index safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)