### PR TITLE
es: unit-scoped skip-publish (detached units publish again) + emulator compatibility

### DIFF
--- a/es/client.go
+++ b/es/client.go
@@ -3,6 +3,7 @@ package es
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -117,7 +118,16 @@ func NewClient(ctx context.Context, pcfg *ProviderConfig, reg Registry) (cli Cli
 			if err != nil {
 				return err
 			}
-			return unit.Handle(innerCtx, group, evt)
+			if err := unit.Handle(innerCtx, group, evt); err != nil {
+				slog.ErrorContext(innerCtx, "bus delivery failed",
+					"group", group,
+					"event", evt.Type,
+					"aggregate_id", evt.AggregateId,
+					"error", err,
+				)
+				return err
+			}
+			return nil
 		})
 		if err := streamer.AddHandler(ctx, name, handler); err != nil {
 			return nil, err

--- a/es/context.go
+++ b/es/context.go
@@ -58,6 +58,12 @@ func GetUnit(ctx context.Context) (Unit, error) {
 }
 func GetSkipPublish(ctx context.Context) bool {
 	skip, ok := ctx.Value(SkipPublishKey).(bool)
+	if !ok {
+		// A unit-scoped skip (see skipPublishFor) also reads as a general
+		// skip for callers that don't identify themselves.
+		_, ok = ctx.Value(SkipPublishKey).(Unit)
+		return ok
+	}
 	return ok && skip
 }
 func GetTime(ctx context.Context) time.Time {
@@ -119,6 +125,27 @@ func SetActor(ctx context.Context, actor *Actor) context.Context {
 }
 func SetSkipPublish(ctx context.Context) context.Context {
 	return context.WithValue(ctx, SkipPublishKey, true)
+}
+
+// skipPublishFor marks publishing as deferred to the given unit: nested
+// dispatches on that unit must not publish (the owning work() will), but a
+// DIFFERENT unit — a detached chunk unit minted inside the handler — still
+// owns its own publishing. An explicit SetSkipPublish(true) suppresses
+// everyone regardless.
+func skipPublishFor(ctx context.Context, u Unit) context.Context {
+	return context.WithValue(ctx, SkipPublishKey, u)
+}
+
+// getSkipPublishFor reports whether publishing is suppressed for this unit:
+// either explicitly for the whole ctx, or unit-scoped to it.
+func getSkipPublishFor(ctx context.Context, u Unit) bool {
+	switch v := ctx.Value(SkipPublishKey).(type) {
+	case bool:
+		return v
+	case Unit:
+		return v == u
+	}
+	return false
 }
 func SetTime(ctx context.Context, t time.Time) context.Context {
 	return context.WithValue(ctx, TimeKey, t)

--- a/es/outbox_test.go
+++ b/es/outbox_test.go
@@ -52,3 +52,20 @@ func TestOutboxPublishBatchPrefix(t *testing.T) {
 	require.Error(t, err)
 	require.Equal(t, []int64{1, 2, 5}, done)
 }
+
+// TestSkipPublishScoping: work()'s internal skip only silences nested
+// dispatches on the SAME unit — a detached unit minted inside a bus handler
+// still publishes (the bug that silently dropped every chunked event from
+// the outbox), while an explicit SetSkipPublish suppresses everyone.
+func TestSkipPublishScoping(t *testing.T) {
+	a, b := &unit{}, &unit{}
+
+	ctx := skipPublishFor(context.Background(), a)
+	require.True(t, getSkipPublishFor(ctx, a), "owning unit defers to its work()")
+	require.False(t, getSkipPublishFor(ctx, b), "a detached unit owns its own publishing")
+	require.True(t, GetSkipPublish(ctx), "unit-scoped skip still reads as skip for anonymous callers")
+
+	explicit := SetSkipPublish(context.Background())
+	require.True(t, getSkipPublishFor(explicit, a))
+	require.True(t, getSkipPublishFor(explicit, b), "explicit skip suppresses everyone")
+}

--- a/es/providers/stream/gpub/streamer.go
+++ b/es/providers/stream/gpub/streamer.go
@@ -160,6 +160,17 @@ func publishRaw(ctx context.Context, topic *pubsub.Topic, orderingKey string, pa
 // paying a round trip per event; the ordering key still serializes
 // same-key messages client-side.
 func publishRawBatch(ctx context.Context, topic *pubsub.Topic, msgs []es.RawEvent) []error {
+	// The emulator's StreamingPullPusher threads crash under concurrent
+	// batched publishes (the v0.5.x sequential trickle never hit this);
+	// emulator runs publish one at a time.
+	if os.Getenv("PUBSUB_EMULATOR_HOST") != "" {
+		errs := make([]error, len(msgs))
+		for i, m := range msgs {
+			errs[i] = publishRaw(ctx, topic, m.OrderingKey, m.Payload)
+		}
+		return errs
+	}
+
 	results := make([]*pubsub.PublishResult, len(msgs))
 	for i, m := range msgs {
 		key := m.OrderingKey

--- a/es/providers/stream/gpub/streamer.go
+++ b/es/providers/stream/gpub/streamer.go
@@ -45,9 +45,11 @@ func (s *streamer) createSubscription(ctx context.Context, suffix string) (*pubs
 	}
 
 	sub, err := s.client.CreateSubscription(ctx, subscriptionId, pubsub.SubscriptionConfig{
-		Topic:                 s.topic,
-		AckDeadline:           10 * time.Second,
-		EnableMessageOrdering: true,
+		Topic:       s.topic,
+		AckDeadline: 10 * time.Second,
+		// Ordered subscriptions route through the emulator's broken
+		// OrderedMessageBacklog even for unkeyed messages — see newTopic.
+		EnableMessageOrdering: os.Getenv("PUBSUB_EMULATOR_HOST") == "",
 		RetryPolicy: &pubsub.RetryPolicy{
 			MinimumBackoff: 10 * time.Millisecond,
 		},

--- a/es/providers/stream/gpub/streamer.go
+++ b/es/providers/stream/gpub/streamer.go
@@ -3,6 +3,7 @@ package gpub
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -133,6 +134,9 @@ func publishEvent(ctx context.Context, topic *pubsub.Topic, evt *es.Event) error
 }
 
 func publishRaw(ctx context.Context, topic *pubsub.Topic, orderingKey string, payload []byte) error {
+	if !topic.EnableMessageOrdering {
+		orderingKey = ""
+	}
 	msg := &pubsub.Message{
 		Data:        payload,
 		OrderingKey: orderingKey,
@@ -156,9 +160,13 @@ func publishRaw(ctx context.Context, topic *pubsub.Topic, orderingKey string, pa
 func publishRawBatch(ctx context.Context, topic *pubsub.Topic, msgs []es.RawEvent) []error {
 	results := make([]*pubsub.PublishResult, len(msgs))
 	for i, m := range msgs {
+		key := m.OrderingKey
+		if !topic.EnableMessageOrdering {
+			key = ""
+		}
 		results[i] = topic.Publish(ctx, &pubsub.Message{
 			Data:        m.Payload,
-			OrderingKey: m.OrderingKey,
+			OrderingKey: key,
 		})
 	}
 
@@ -174,7 +182,11 @@ func publishRawBatch(ctx context.Context, topic *pubsub.Topic, msgs []es.RawEven
 
 func newTopic(client *pubsub.Client, topicId string) *pubsub.Topic {
 	topic := client.Topic(topicId)
-	topic.EnableMessageOrdering = true
+	// The Pub/Sub emulator's ordered-message backlog is broken (pulls NPE
+	// once keyed messages accumulate — messages become undeliverable), so
+	// emulator runs publish unordered; publishRaw/publishRawBatch strip
+	// ordering keys to match, as the client requires.
+	topic.EnableMessageOrdering = os.Getenv("PUBSUB_EMULATOR_HOST") == ""
 	topic.PublishSettings.ByteThreshold = 5000
 	topic.PublishSettings.CountThreshold = 10
 	topic.PublishSettings.DelayThreshold = 100 * time.Millisecond

--- a/es/unit.go
+++ b/es/unit.go
@@ -105,7 +105,7 @@ func (u *unit) work(ctx context.Context, fn func(ctx context.Context) error) (er
 		return fmt.Errorf("beginning transaction fail: %w", err)
 	}
 
-	skipPublish := GetSkipPublish(ctx)
+	skipPublish := getSkipPublishFor(ctx, u)
 
 	defer func() {
 		if perr := recover(); perr != nil {
@@ -118,7 +118,7 @@ func (u *unit) work(ctx context.Context, fn func(ctx context.Context) error) (er
 		}
 	}()
 
-	sctx := SetSkipPublish(ctx)
+	sctx := skipPublishFor(ctx, u)
 	if err = fn(sctx); err != nil {
 		return
 	}


### PR DESCRIPTION
## ⚠️ Contains a correctness fix that BLOCKS inflow api#86/api#87

**Bug (found E2E-testing the chunked flows locally):** \`work()\` sets skip-publish on the handler ctx so nested dispatches on the delivery unit don't double-publish. A detached unit minted inside the handler **inherited that flag** — every event committed through a chunked dispatch wrote *no outbox rows* and was silently never published. Locally, a mass payout wedged in \`finalizing\` identically on both a Pub/Sub-emulator and a NATS stack (the profile confirm was never sent). In prod this would have broken every chunked leg the moment api#86/#87 deployed.

**Fix:** the internal skip now carries the owning unit — nested dispatches on that unit stay silenced, a *different* (detached) unit owns its own publishing, and the public \`SetSkipPublish\` still suppresses everyone. \`TestSkipPublishScoping\` covers the three cases.

**Why nothing caught it earlier:** the api E2E asserted DB state (which commits fine), not publication; the lib's detached-unit test dispatched without a delivery-wrapped ctx; and bus handler errors vanish into the unread streamer errors channel — **MessageHandler now logs delivery failures before nacking** to close that observability hole.

## Emulator compatibility (the rest of the branch)
The Pub/Sub emulator's ordered backlog NPEs and its \`StreamingPullPusher\` threads crash under concurrent batched publishes. When \`PUBSUB_EMULATOR_HOST\` is set: topic + self-provisioned subscriptions disable message ordering, and batch publish degrades to sequential. No behavior change against real Pub/Sub.

**Verified:** full masspayout create→import→finalize E2E on the local stack streams live progress end to end (importing 0/60 → processed → finalizing → finalized with 40 processing / 20 held) and settles. Lib + example suites green.

Proposed tag: **v0.6.2** — inflow api#86/#87 must bump to it before merging.